### PR TITLE
kalabox/kalabox#1232 - Adding functional tests to test removal of app

### DIFF
--- a/test/backdrop/finish.bats
+++ b/test/backdrop/finish.bats
@@ -21,8 +21,16 @@ setup() {
 @test "Check that we can run '$KBOX rebuild' without an error." {
   $KBOX $PHP_BACKDROP_NAME rebuild
 }
+@test "Check that the app's directory exists before destroy is run." {
+  run ls -l $KBOX_APP_DIR/$PHP_BACKDROP_NAME
+  [ "$status" -eq 0 ]
+}
 @test "Check that we can run '$KBOX destroy' without an error." {
   $KBOX $PHP_BACKDROP_NAME destroy -- -y
+}
+@test "Check that the app's directory was removed." {
+  run ls -l $KBOX_APP_DIR/$PHP_BACKDROP_NAME
+  [ "$status" -eq 1 ]
 }
 
 #

--- a/test/backdrop/finish.bats
+++ b/test/backdrop/finish.bats
@@ -22,15 +22,23 @@ setup() {
   $KBOX $PHP_BACKDROP_NAME rebuild
 }
 @test "Check that the app's directory exists before destroy is run." {
-  run ls -l $KBOX_APP_DIR/$PHP_BACKDROP_NAME
-  [ "$status" -eq 0 ]
+  if [ ! -d "$KBOX_APP_DIR/$PHP_BACKDROP_NAME" ]; then
+    run foo
+    [ "$status" -eq 0 ]
+  else
+    skip "OK"
+  fi
 }
 @test "Check that we can run '$KBOX destroy' without an error." {
   $KBOX $PHP_BACKDROP_NAME destroy -- -y
 }
 @test "Check that the app's directory was removed." {
-  run ls -l $KBOX_APP_DIR/$PHP_BACKDROP_NAME
-  [ "$status" -eq 1 ]
+  if [ -d "$KBOX_APP_DIR/$PHP_BACKDROP_NAME" ]; then
+    run foo
+    [ "$status" -eq 0 ]
+  else
+    skip "OK"
+  fi
 }
 
 #

--- a/test/drupal7/finish.bats
+++ b/test/drupal7/finish.bats
@@ -21,8 +21,16 @@ setup() {
 @test "Check that we can run '$KBOX rebuild' without an error." {
   $KBOX $PHP_DRUPAL7_NAME rebuild
 }
+@test "Check that the app's directory exists before destroy is run." {
+  run ls -l $KBOX_APP_DIR/$PHP_DRUPAL7_NAME
+  [ "$status" -eq 0 ]
+}
 @test "Check that we can run '$KBOX destroy' without an error." {
   $KBOX $PHP_DRUPAL7_NAME destroy -- -y
+}
+@test "Check that the app's directory was removed." {
+  run ls -l $KBOX_APP_DIR/$PHP_DRUPAL7_NAME
+  [ "$status" -eq 1 ]
 }
 
 #

--- a/test/drupal7/finish.bats
+++ b/test/drupal7/finish.bats
@@ -22,15 +22,23 @@ setup() {
   $KBOX $PHP_DRUPAL7_NAME rebuild
 }
 @test "Check that the app's directory exists before destroy is run." {
-  run ls -l $KBOX_APP_DIR/$PHP_DRUPAL7_NAME
-  [ "$status" -eq 0 ]
+  if [ ! -d "$KBOX_APP_DIR/$PHP_DRUPAL7_NAME" ]; then
+    run foo
+    [ "$status" -eq 0 ]
+  else
+    skip "OK"
+  fi
 }
 @test "Check that we can run '$KBOX destroy' without an error." {
   $KBOX $PHP_DRUPAL7_NAME destroy -- -y
 }
 @test "Check that the app's directory was removed." {
-  run ls -l $KBOX_APP_DIR/$PHP_DRUPAL7_NAME
-  [ "$status" -eq 1 ]
+  if [ -d "$KBOX_APP_DIR/$PHP_DRUPAL7_NAME" ]; then
+    run foo
+    [ "$status" -eq 0 ]
+  else
+    skip "OK"
+  fi
 }
 
 #

--- a/test/drupal8/finish.bats
+++ b/test/drupal8/finish.bats
@@ -22,15 +22,23 @@ setup() {
   $KBOX $PHP_DRUPAL8_NAME rebuild
 }
 @test "Check that the app's directory exists before destroy is run." {
-  run ls -l $KBOX_APP_DIR/$PHP_DRUPAL8_NAME
-  [ "$status" -eq 0 ]
+  if [ ! -d "$KBOX_APP_DIR/$PHP_DRUPAL8_NAME" ]; then
+    run foo
+    [ "$status" -eq 0 ]
+  else
+    skip "OK"
+  fi
 }
 @test "Check that we can run '$KBOX destroy' without an error." {
   $KBOX $PHP_DRUPAL8_NAME destroy -- -y
 }
 @test "Check that the app's directory was removed." {
-  run ls -l $KBOX_APP_DIR/$PHP_DRUPAL8_NAME
-  [ "$status" -eq 1 ]
+  if [ -d "$KBOX_APP_DIR/$PHP_DRUPAL8_NAME" ]; then
+    run foo
+    [ "$status" -eq 0 ]
+  else
+    skip "OK"
+  fi
 }
 
 #

--- a/test/drupal8/finish.bats
+++ b/test/drupal8/finish.bats
@@ -21,8 +21,16 @@ setup() {
 @test "Check that we can run '$KBOX rebuild' without an error." {
   $KBOX $PHP_DRUPAL8_NAME rebuild
 }
+@test "Check that the app's directory exists before destroy is run." {
+  run ls -l $KBOX_APP_DIR/$PHP_DRUPAL8_NAME
+  [ "$status" -eq 0 ]
+}
 @test "Check that we can run '$KBOX destroy' without an error." {
   $KBOX $PHP_DRUPAL8_NAME destroy -- -y
+}
+@test "Check that the app's directory was removed." {
+  run ls -l $KBOX_APP_DIR/$PHP_DRUPAL8_NAME
+  [ "$status" -eq 1 ]
 }
 
 #

--- a/test/wordpress/finish.bats
+++ b/test/wordpress/finish.bats
@@ -21,8 +21,16 @@ setup() {
 @test "Check that we can run '$KBOX rebuild' without an error." {
   $KBOX $PHP_WORDPRESS_NAME rebuild
 }
+@test "Check that the app's directory exists before destroy is run." {
+  run ls -l $KBOX_APP_DIR/$PHP_WORDPRESS_NAME
+  [ "$status" -eq 0 ]
+}
 @test "Check that we can run '$KBOX destroy' without an error." {
   $KBOX $PHP_WORDPRESS_NAME destroy -- -y
+}
+@test "Check that the app's directory was removed." {
+  run ls -l $KBOX_APP_DIR/$PHP_WORDPRESS_NAME
+  [ "$status" -eq 1 ]
 }
 
 #

--- a/test/wordpress/finish.bats
+++ b/test/wordpress/finish.bats
@@ -22,15 +22,23 @@ setup() {
   $KBOX $PHP_WORDPRESS_NAME rebuild
 }
 @test "Check that the app's directory exists before destroy is run." {
-  run ls -l $KBOX_APP_DIR/$PHP_WORDPRESS_NAME
-  [ "$status" -eq 0 ]
+  if [ ! -d "$KBOX_APP_DIR/$PHP_WORDPRESS_NAME" ]; then
+    run foo
+    [ "$status" -eq 0 ]
+  else
+    skip "OK"
+  fi
 }
 @test "Check that we can run '$KBOX destroy' without an error." {
   $KBOX $PHP_WORDPRESS_NAME destroy -- -y
 }
 @test "Check that the app's directory was removed." {
-  run ls -l $KBOX_APP_DIR/$PHP_WORDPRESS_NAME
-  [ "$status" -eq 1 ]
+  if [ -d "$KBOX_APP_DIR/$PHP_WORDPRESS_NAME" ]; then
+    run foo
+    [ "$status" -eq 0 ]
+  else
+    skip "OK"
+  fi
 }
 
 #


### PR DESCRIPTION
Thank you so much for contributing code to Kalabox!

We will get to your PR as soon as we can but in the meantime you might want to
check to make sure you have done the following. **The more boxes you can check
the easier it will be for us to merge in your changes with confidence**
- [x] My code passes relevant CI status checks
- [x] My code includes a test ([see here](https://github.com/kalabox/kalabox-app-pantheon/blob/HEAD/CONTRIBUTING.md))
- [x] My code includes an update to `CHANGELOG.md` ([see here](https://github.com/kalabox/kalabox-app-pantheon/blob/HEAD/CHANGELOG.md))
- [x] My code includes documentation updates if relevant.
- [x] I have pinged @pirog when I think my code is ready for prime time.

If you are unclear about any of the above please add comments below so we can
improve our process.

directory after app is removed.
